### PR TITLE
feat: allow user to register an episode

### DIFF
--- a/app/(home)/_layout.tsx
+++ b/app/(home)/_layout.tsx
@@ -1,10 +1,69 @@
-import React from "react";
-import { Stack } from "expo-router";
+import { Tabs } from "expo-router";
+import { View, Text, Image } from "react-native";
+import { useColorScheme } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
 
-export default function _layout() {
+export default function TabLayout() {
+  const colorScheme = useColorScheme();
+
   return (
-    <Stack>
-      <Stack.Screen name="welcome" options={{ headerShown: false }} />
-    </Stack>
+    <Tabs
+      screenOptions={{
+        headerShown: false,
+        tabBarActiveTintColor: "#002D3D",
+        tabBarInactiveTintColor: "#A0A0A0",
+        tabBarLabelStyle: {
+          fontSize: 12,
+        },
+        tabBarStyle: {
+          backgroundColor: "#FFFFFF",
+          borderTopColor: "#E5E5E5",
+          height: 65,
+          paddingBottom: 10,
+        },
+      }}
+    >
+      <Tabs.Screen
+        name="home"
+        options={{
+          title: "Home",
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="home" color={color} size={size} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="history"
+        options={{
+          title: "Histórico",
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="time" color={color} size={size} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="profile"
+        options={{
+          title: "Perfil",
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="person" color={color} size={size} />
+          ),
+        }}
+      />
+
+      <Tabs.Screen
+        name="newEpisode"
+        options={{
+          href: null,
+        }}
+      />
+
+      <Tabs.Screen
+        name="welcome"
+        options={{
+          href: null,
+        }}
+      />
+    </Tabs>
   );
 }

--- a/app/(home)/history.tsx
+++ b/app/(home)/history.tsx
@@ -1,0 +1,9 @@
+import { View, Text } from "react-native";
+
+export default function history() {
+  return (
+    <View className="flex-1 px-4 py-6 bg-white">
+      <Text className="text-3xl font-bold mb-4 text-center">Histórico de crises</Text>
+    </View>
+  );
+}

--- a/app/(home)/home.tsx
+++ b/app/(home)/home.tsx
@@ -1,28 +1,40 @@
 import { View, Text, TouchableOpacity } from "react-native";
 import React from "react";
-import { useRouter } from "expo-router";
 import useAuth from "@/firebase/hooks/useAuth";
+import { useRouter } from "expo-router";
 
 export default function home() {
-  const { logout } = useAuth();
+  const { logout, user } = useAuth();
   const router = useRouter();
 
-  const handleLogout = async () => {
-    try {
-      await logout();
-      router.replace("/");
-    } catch (error: any) {
-      alert("Erro ao sair: " + error.message);
-    }
+  const firstName = user?.displayName?.split(" ")[0] || "tudo bem?";
+
+  const handleLogout = () => {
+    logout().then(() => {
+      router.push("/");
+    }).catch((error) => {
+      console.error("Logout failed:", error);
+    });
   };
+
   return (
-    <View>
-      <Text>home</Text>
+    <View className="flex-1 px-4 py-6 bg-white">
+      <Text className="text-3xl font-bold mb-4">Olá, {firstName}!</Text>
+
       <TouchableOpacity
-        className="rounded-md py-4 items-center mb-6 bg-cyan-800"
+        className="w-full rounded-md py-4 items-center mb-6 bg-cyan-800"
+        onPress={() => router.push("/(home)/newEpisode")}
+      >
+        <Text className="font-semibold text-white">Registrar novo episódio</Text>
+      </TouchableOpacity>
+
+      <TouchableOpacity 
+        className="w-full rounded-md py-4 items-center bg-slate-300 text-center"
         onPress={handleLogout}
       >
-        <Text className="font-semibold text-white">Sair</Text>
+        <Text className="text-base font-semibold">
+          Logout
+        </Text>
       </TouchableOpacity>
     </View>
   );

--- a/app/(home)/newEpisode.tsx
+++ b/app/(home)/newEpisode.tsx
@@ -1,0 +1,214 @@
+import { useRouter } from "expo-router";
+import {
+  Alert,
+  ScrollView,
+  Text,
+  TextInput,
+  View,
+  Platform,
+  KeyboardAvoidingView,
+  TouchableOpacity,
+} from "react-native";
+import { useState } from "react";
+import Slider from "@react-native-community/slider";
+import type { Episode } from "@/types/Episode";
+import useCollection from "@/firebase/hooks/useCollection";
+import useAuth from "@/firebase/hooks/useAuth";
+import SelectionButton from "@/components/SelectionButton";
+import DayPeriodSelector from "@/components/DayPeriodSelector";
+import DateSelector from "@/components/DateSelector";
+import { X } from "lucide-react-native";
+
+const periods = ["Madrugada", "Manhã", "Tarde", "Noite"];
+const painLocations = [
+  "Lado esquerdo",
+  "Lado direito",
+  "Topo da cabeça",
+  "Atrás da cabeça",
+  "Cabeça Inteira",
+];
+const symptomsOptions = [
+  "Náusea",
+  "Sensibilidade à luz",
+  "Sensibilidade ao som",
+  "Tontura",
+];
+const triggersOptions = [
+  "Desidratação",
+  "Falta de sono",
+  "Estresse",
+  "Álcool",
+  "Alimentação",
+  "Mudança climática",
+];
+
+export default function newEpisode() {
+  const { user } = useAuth();
+  const router = useRouter();
+  const { create, refreshData } = useCollection<Episode>("episodes");
+
+  const [date, setDate] = useState(new Date());
+  const [dayPeriod, setDayPeriod] = useState<string>("Manhã");
+  const [intensity, setIntensity] = useState<number>(4);
+  const [painLocation, setPainLocation] = useState<string[]>([]);
+  const [symptoms, setSymptoms] = useState<string[]>([]);
+  const [triggers, setTriggers] = useState<string[]>([]);
+  const [medication, setMedication] = useState<string>("");
+  const [medicationOutcome, setMedicationOutcome] = useState<string>("");
+  const [notes, setNotes] = useState<string>("");
+
+  const toggleSelection = (
+    value: string,
+    list: string[],
+    setList: (val: string[]) => void
+  ) => {
+    if (list.includes(value)) {
+      setList(list.filter((item) => item !== value));
+    } else {
+      setList([...list, value]);
+    }
+  };
+
+  const handleRegister = async () => {
+    const newEpisode: Episode = {
+      userId: user?.uid ?? "anonymous",
+      timestamp: date,
+      dayPeriod,
+      intensity,
+      painLocation,
+      symptoms,
+      triggers,
+      medication,
+      medicationOutcome,
+      notes,
+    };
+
+    try {
+      await create(newEpisode);
+      refreshData();
+      Alert.alert("Sucesso", "Episódio registrado com sucesso!");
+      router.back();
+    } catch (error: any) {
+      Alert.alert("Erro", error.toString());
+    }
+  };
+
+  return (
+    <KeyboardAvoidingView
+      className="flex-1 bg-white px-5 pt-6"
+      behavior={Platform.OS === "ios" ? "padding" : "height"}
+      keyboardVerticalOffset={80}
+    >
+      <ScrollView keyboardShouldPersistTaps="handled">
+        <View className="flex flex-row items-center justify-center mb-6">
+          <TouchableOpacity
+            onPress={() => router.back()}
+            className="mr-auto"
+          >
+            <X size={16} color="#141414" />
+          </TouchableOpacity>
+          <Text className="text-2xl font-bold mr-auto">
+            Novo episódio
+          </Text>
+        </View>
+
+        <DateSelector
+          date={date}
+          onDateChange={setDate}
+        />
+
+        <DayPeriodSelector
+          periods={periods}
+          selectedPeriod={dayPeriod}
+          onSelectPeriod={setDayPeriod}
+        />
+
+        <Text className="font-medium">
+          Intensidade da dor: {intensity}
+        </Text>
+        <Slider
+          value={intensity}
+          onValueChange={setIntensity}
+          minimumValue={0}
+          maximumValue={10}
+          step={1}
+          minimumTrackTintColor="#141414"
+          maximumTrackTintColor="#E0E3E2"
+          thumbTintColor="#141414"
+        />
+
+        <Text className="font-medium my-4">Local da dor</Text>
+        <View className="flex-row flex-wrap gap-2 mb-6">
+          {painLocations.map((location) => (
+            <SelectionButton
+              key={location}
+              label={location}
+              isSelected={painLocation.includes(location)}
+              onPress={() => toggleSelection(location, painLocation, setPainLocation)}
+            />
+          ))}
+        </View>
+
+        <Text className="font-medium mb-4">Sintomas</Text>
+        <View className="flex-row flex-wrap gap-2 mb-6">
+          {symptomsOptions.map((symptom) => (
+            <SelectionButton
+              key={symptom}
+              label={symptom}
+              isSelected={symptoms.includes(symptom)}
+              onPress={() => toggleSelection(symptom, symptoms, setSymptoms)}
+            />
+          ))}
+        </View>
+
+        <Text className="font-medium mb-4">Gatilhos</Text>
+        <View className="flex-row flex-wrap gap-2 mb-6">
+          {triggersOptions.map((trigger) => (
+            <SelectionButton
+              key={trigger}
+              label={trigger}
+              isSelected={triggers.includes(trigger)}
+              onPress={() => toggleSelection(trigger, triggers, setTriggers)}
+            />
+          ))}
+        </View>
+
+        <Text className="font-medium mb-4">Medicação</Text>
+        <TextInput
+          className="bg-gray-100 rounded-lg p-3 mb-4"
+          placeholder="Medicamento utilizado"
+          value={medication}
+          onChangeText={setMedication}
+        />
+        <TextInput
+          className="bg-gray-100 rounded-lg p-3 mb-4"
+          placeholder="Resultado, funcionou?"
+          value={medicationOutcome}
+          onChangeText={setMedicationOutcome}
+        />
+        <TextInput
+          className="bg-gray-100 rounded-lg p-3 mb-6 h-28"
+          placeholder="Notas adicionais"
+          value={notes}
+          onChangeText={setNotes}
+          multiline
+        />
+
+        <View className="flex-row justify-between mb-10">
+          <TouchableOpacity
+            onPress={() => router.back()}
+            className="px-6 py-3 bg-gray-200 rounded-lg"
+          >
+            <Text className="text-black font-medium">Cancelar</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={handleRegister}
+            className="px-6 py-3 bg-[#2A667F] rounded-lg"
+          >
+            <Text className="text-white font-semibold">Registrar</Text>
+          </TouchableOpacity>
+        </View>
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+}

--- a/app/(home)/profile.tsx
+++ b/app/(home)/profile.tsx
@@ -1,0 +1,9 @@
+import { View, Text } from "react-native";
+
+export default function profile() {
+  return (
+    <View className="flex-1 px-4 py-6 bg-white">
+      <Text className="text-3xl font-bold mb-4 text-center">Perfil</Text>
+    </View>
+  );
+}

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -20,7 +20,6 @@ export default function Login() {
   const handleLogin = async () => {
     try {
       await login(email, password);
-      console.log("User logged in:", user);
       router.replace("/(home)/home");
     } catch (error: any) {
       Alert.alert("Login error:", error.toString());
@@ -37,7 +36,7 @@ export default function Login() {
         placeholder="Email"
         keyboardType="email-address"
         autoCapitalize="none"
-        className="w-full rounded-md p-4 mb-4 text-base bg-slate-100"
+        className="w-full rounded-md p-4 mb-4 bg-slate-100"
         value={email}
         onChangeText={setEmail}
       />
@@ -45,7 +44,7 @@ export default function Login() {
       <TextInput
         placeholder="Senha"
         secureTextEntry
-        className="w-full rounded-md p-4 mb-4 text-base bg-slate-100"
+        className="w-full rounded-md p-4 mb-4 bg-slate-100"
         value={password}
         onChangeText={setPassword}
       />

--- a/components/DateSelector.tsx
+++ b/components/DateSelector.tsx
@@ -1,0 +1,44 @@
+import { useState } from "react";
+import { View, Text, TouchableOpacity, Platform } from "react-native";
+import { DateTime } from "luxon";
+import DateTimePicker, { DateTimePickerEvent } from "@react-native-community/datetimepicker";
+
+interface DateSelectorProps {
+  date: Date;
+  onDateChange: (date: Date) => void;
+}
+
+export default function DateSelector({ date, onDateChange }: DateSelectorProps) {
+  const [showDatePicker, setShowDatePicker] = useState(false);
+
+  const handleDateChange = (event: DateTimePickerEvent, selectedDate?: Date) => {
+    setShowDatePicker(Platform.OS === "ios");
+    if (selectedDate) {
+      onDateChange(selectedDate);
+    }
+  };
+
+  return (
+    <View>
+      <Text className="font-medium mb-3">Data</Text>
+
+      <TouchableOpacity
+        onPress={() => setShowDatePicker(true)}
+        className="bg-gray-100 rounded-lg p-3 mb-6"
+      >
+        <Text className="text-gray-500">
+          {DateTime.fromJSDate(date).toFormat("dd/LL/yyyy")}
+        </Text>
+      </TouchableOpacity>
+
+      {showDatePicker && (
+        <DateTimePicker
+          value={date}
+          mode="date"
+          display="default"
+          onChange={handleDateChange}
+        />
+      )}
+    </View>
+  );
+} 

--- a/components/DayPeriodSelector.tsx
+++ b/components/DayPeriodSelector.tsx
@@ -1,0 +1,39 @@
+import { View, Text, TouchableOpacity } from "react-native";
+import { Feather } from "@expo/vector-icons";
+
+interface DayPeriodSelectorProps {
+  periods: string[];
+  selectedPeriod: string;
+  onSelectPeriod: (period: string) => void;
+}
+
+export default function DayPeriodSelector({ 
+  periods, 
+  selectedPeriod, 
+  onSelectPeriod 
+}: DayPeriodSelectorProps) {
+  return (
+    <View>
+      <View className="flex flex-row items-center gap-2 mb-4">
+        <View className="bg-gray-100 p-2 rounded-lg">
+          <Feather name="sun" color="#70787A" size={20} />
+        </View>
+        <Text className="font-medium">Período do dia</Text>
+      </View>
+
+      <View className="flex flex-row flex-wrap gap-2 mb-6">
+        {periods.map((period) => (
+          <TouchableOpacity
+            key={period}
+            className={`px-4 py-4 w-44 rounded-lg border ${
+              selectedPeriod === period ? "border-black" : "border-gray-300"
+            }`}
+            onPress={() => onSelectPeriod(period)}
+          >
+            <Text>{period}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+    </View>
+  );
+}

--- a/components/SelectionButton.tsx
+++ b/components/SelectionButton.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { TouchableOpacity, Text } from "react-native";
+
+interface SelectionButtonProps {
+  label: string;
+  isSelected: boolean;
+  onPress: () => void;
+}
+
+export default function SelectionButton({ label, isSelected, onPress }: SelectionButtonProps) {
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      className={`px-4 py-2 rounded-lg ${
+        isSelected ? "bg-gray-300" : "bg-gray-100"
+      }`}
+    >
+      <Text>{label}</Text>
+    </TouchableOpacity>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -9,9 +9,13 @@
     "web": "expo start --web"
   },
   "dependencies": {
+    "@expo/vector-icons": "^14.1.0",
     "@react-native-async-storage/async-storage": "2.1.2",
+    "@react-native-community/datetimepicker": "^8.4.1",
+    "@react-native-community/slider": "^4.5.7",
     "@rneui/base": "^4.0.0-rc.8",
     "@rneui/themed": "^4.0.0-rc.8",
+    "@types/luxon": "^3.6.2",
     "expo": "^53.0.9",
     "expo-constants": "~17.1.6",
     "expo-linking": "~7.1.5",
@@ -19,6 +23,7 @@
     "expo-splash-screen": "~0.30.8",
     "expo-status-bar": "~2.2.3",
     "firebase": "^11.8.1",
+    "lucide-react-native": "^0.511.0",
     "luxon": "^3.6.1",
     "nativewind": "^4.1.23",
     "react": "19.0.0",
@@ -26,6 +31,7 @@
     "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.10.0",
+    "react-native-svg": "^15.12.0",
     "tailwindcss": "^3.4.17",
     "zustand": "^5.0.5"
   },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ["./app/**/*.{js,jsx,ts,tsx}", "./src/**/*.{js,jsx,ts,tsx}"],
+  content: ["./app/**/*.{js,jsx,ts,tsx}", "./components/**/*.{js,jsx,ts,tsx}"],
   presets: [require("nativewind/preset")],
   theme: {
     extend: {},

--- a/types/Episode.ts
+++ b/types/Episode.ts
@@ -1,0 +1,13 @@
+export interface Episode {
+  id?: string; // reserved for firestore id
+  userId: string;
+  timestamp: Date;
+  dayPeriod: string;
+  intensity: number;
+  painLocation: string[];
+  symptoms: string[];
+  triggers: string[];
+  medication: string;
+  medicationOutcome: string;
+  notes: string;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1063,7 +1063,7 @@
   resolved "https://registry.yarnpkg.com/@expo/sudo-prompt/-/sudo-prompt-9.3.2.tgz#0fd2813402a42988e49145cab220e25bea74b308"
   integrity sha512-HHQigo3rQWKMDzYDLkubN5WQOYXJJE2eNqIQC2axC2iO3mHdwnIR7FgZVvHWtBwAdzBgAP0ECp8KqS8TiMKvgw==
 
-"@expo/vector-icons@^14.0.0":
+"@expo/vector-icons@^14.0.0", "@expo/vector-icons@^14.1.0":
   version "14.1.0"
   resolved "https://registry.yarnpkg.com/@expo/vector-icons/-/vector-icons-14.1.0.tgz#d3dddad8b6ea60502e0fe5485b86751827606ce4"
   integrity sha512-7T09UE9h8QDTsUeMGymB4i+iqvtEeaO5VvUjryFB4tugDTG/bkzViWA74hm5pfjjDEhYMXWaX112mcvhccmIwQ==
@@ -1739,6 +1739,18 @@
   dependencies:
     merge-options "^3.0.4"
 
+"@react-native-community/datetimepicker@^8.4.1":
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/@react-native-community/datetimepicker/-/datetimepicker-8.4.1.tgz#a798c237f01ae96658d5c93292fc2955dad04a83"
+  integrity sha512-DrK+CUS5fZnz8dhzBezirkzQTcNDdaXer3oDLh0z4nc2tbdIdnzwvXCvi8IEOIvleoc9L95xS5tKUl0/Xv71Mg==
+  dependencies:
+    invariant "^2.2.4"
+
+"@react-native-community/slider@^4.5.7":
+  version "4.5.7"
+  resolved "https://registry.yarnpkg.com/@react-native-community/slider/-/slider-4.5.7.tgz#523178779f302aa162b0d57211842f81522e8ece"
+  integrity sha512-WMDDZjNF2Bd8M8TrSqKf5xhM9ikdfCHtSPur64Ow3bB/OVrKufUQZ59NmYdNZNeGPvcHHTsafuYTY8zfZfbchQ==
+
 "@react-native/assets-registry@0.79.2":
   version "0.79.2"
   resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.79.2.tgz#731963e664c8543f5b277e56c058bde612b69f50"
@@ -2026,6 +2038,11 @@
   version "7.0.15"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
+
+"@types/luxon@^3.6.2":
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-3.6.2.tgz#be6536931801f437eafcb9c0f6d6781f72308041"
+  integrity sha512-R/BdP7OxEMc44l2Ex5lSXHoIXTB2JLNa3y2QISIbr58U/YcsffyQrYW//hZSdrfxrjRZj3GcUoxMPGdO8gSYuw==
 
 "@types/node@*":
   version "22.14.1"
@@ -2413,6 +2430,11 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.3.0.tgz#f6e14a97858d327252200242d4ccfe522c445522"
   integrity sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==
 
+boolbase@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+  integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
+
 bplist-creator@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/bplist-creator/-/bplist-creator-0.1.0.tgz#018a2d1b587f769e379ef5519103730f8963ba1e"
@@ -2785,6 +2807,30 @@ crypto-random-string@^2.0.0:
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
   integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
 
+css-select@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-5.1.0.tgz#b8ebd6554c3637ccc76688804ad3f6a6fdaea8a6"
+  integrity sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==
+  dependencies:
+    boolbase "^1.0.0"
+    css-what "^6.1.0"
+    domhandler "^5.0.2"
+    domutils "^3.0.1"
+    nth-check "^2.0.1"
+
+css-tree@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.1.3.tgz#eb4870fb6fd7707327ec95c2ff2ab09b5e8db91d"
+  integrity sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==
+  dependencies:
+    mdn-data "2.0.14"
+    source-map "^0.6.1"
+
+css-what@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.1.0.tgz#fb5effcf76f1ddea2c81bdfaa4de44e79bac70f4"
+  integrity sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==
+
 cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
@@ -2880,6 +2926,36 @@ dlv@^1.1.3:
   resolved "https://registry.yarnpkg.com/dlv/-/dlv-1.1.3.tgz#5c198a8a11453596e751494d49874bc7732f2e79"
   integrity sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==
 
+dom-serializer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-2.0.0.tgz#e41b802e1eedf9f6cae183ce5e622d789d7d8e53"
+  integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.2"
+    entities "^4.2.0"
+
+domelementtype@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
+  integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
+
+domhandler@^5.0.2, domhandler@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
+  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
+  dependencies:
+    domelementtype "^2.3.0"
+
+domutils@^3.0.1:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.2.2.tgz#edbfe2b668b0c1d97c24baf0f1062b132221bc78"
+  integrity sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==
+  dependencies:
+    dom-serializer "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+
 dotenv-expand@~11.0.6:
   version "11.0.7"
   resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-11.0.7.tgz#af695aea007d6fdc84c86cd8d0ad7beb40a0bd08"
@@ -2931,6 +3007,11 @@ encodeurl@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-2.0.0.tgz#7b8ea898077d7e409d3ac45474ea38eaf0857a58"
   integrity sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==
+
+entities@^4.2.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
+  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
 env-editor@^0.4.1:
   version "0.4.2"
@@ -3983,6 +4064,11 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+lucide-react-native@^0.511.0:
+  version "0.511.0"
+  resolved "https://registry.yarnpkg.com/lucide-react-native/-/lucide-react-native-0.511.0.tgz#f62dc1a4754b902947dae88baf78612aa5a7a77e"
+  integrity sha512-brCrakogilGx3inT0em8HUU11dsxyu62+P6sjqU7WKgkfcIc8Q0Ya3zDcBQ8EG3c1HsCSvgFT5tWLetVFAsqhQ==
+
 luxon@^3.6.1:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.6.1.tgz#d283ffc4c0076cb0db7885ec6da1c49ba97e47b0"
@@ -3999,6 +4085,11 @@ marky@^1.2.2:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/marky/-/marky-1.3.0.tgz#422b63b0baf65022f02eda61a238eccdbbc14997"
   integrity sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==
+
+mdn-data@2.0.14:
+  version "2.0.14"
+  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.14.tgz#7113fc4281917d63ce29b43446f701e68c25ba50"
+  integrity sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==
 
 memoize-one@^5.0.0:
   version "5.2.1"
@@ -4368,6 +4459,13 @@ npm-package-arg@^11.0.0:
     proc-log "^4.0.0"
     semver "^7.3.5"
     validate-npm-package-name "^5.0.0"
+
+nth-check@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
+  integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
+  dependencies:
+    boolbase "^1.0.0"
 
 nullthrows@^1.1.1:
   version "1.1.1"
@@ -4842,6 +4940,15 @@ react-native-size-matters@^0.4.0:
   resolved "https://registry.yarnpkg.com/react-native-size-matters/-/react-native-size-matters-0.4.2.tgz#4348bdd6fc47383f60326d58ad69870c998a5f9a"
   integrity sha512-DKE3f/sdcozd24oASgkP1iGg+YU3HoajRa5k3a4wkRzpiqREq8SGX12Y5zBgAt/8IivLQoTMYkyQu1/Giuy+zQ==
 
+react-native-svg@^15.12.0:
+  version "15.12.0"
+  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-15.12.0.tgz#0e2d476961e8b07f8c549fe4489c99b5130dc150"
+  integrity sha512-iE25PxIJ6V0C6krReLquVw6R0QTsRTmEQc4K2Co3P6zsimU/jltcDBKYDy1h/5j9S/fqmMeXnpM+9LEWKJKI6A==
+  dependencies:
+    css-select "^5.1.0"
+    css-tree "^1.1.3"
+    warn-once "0.1.1"
+
 react-native@0.79.2:
   version "0.79.2"
   resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.79.2.tgz#f1a53099701c1736d09e441eb79f97cfc90dd202"
@@ -5232,7 +5339,7 @@ source-map@^0.5.6:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==
 
-source-map@^0.6.0:
+source-map@^0.6.0, source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
@@ -5641,7 +5748,7 @@ walker@^1.0.7, walker@^1.0.8:
   dependencies:
     makeerror "1.0.12"
 
-warn-once@^0.1.0, warn-once@^0.1.1:
+warn-once@0.1.1, warn-once@^0.1.0, warn-once@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/warn-once/-/warn-once-0.1.1.tgz#952088f4fb56896e73fd4e6a3767272a3fccce43"
   integrity sha512-VkQZJbO8zVImzYFteBXvBOZEl1qL175WH8VmZcxF2fZAoudNhNDvHi+doCaAEdU2l2vtcIwa2zn0QK5+I1HQ3Q==


### PR DESCRIPTION
- Criação da tela de registro de um episódio de cefaleia, já integrado com o firebase
- Implementação de navegação por tabs usando expo-router
  - Adição de três tabs principais: Home, Histórico e Perfil
  - Ocultação de telas específicas (newEpisode e welcome) da navegação por tabs

- Criação de componentes reutilizáveis:
  - SelectionButton: Para botões de seleção múltipla
  - DayPeriodSelector: Para seleção de período do dia
  - DateSelector: Para seleção de data com DateTimePicker

### **Pequenos updates**

- Saudação personalizada usando o primeiro nome do usuário na tela home
- Botão de "Registrar novo episódio" em destaque
- Reposicionamento do botão de logout

### **Dependências adicionadas**

- Adição de novas dependências:
- @expo/vector-icons: Para ícones
- @react-native-community/datetimepicker: Para seleção de data
- @react-native-community/slider: Para controle deslizante
- lucide-react-native: Para ícones adicionais
- react-native-svg: Para suporte a SVG

### **Correções de bugs**

- Atualização do tailwind.config.js para incluir a pasta de componentes, pois não estava aplicando estilo nos componentes dentro deste diretório.
- Ajustes nas configurações do Metro bundler para funcionar com o hook `useAuth()`
- Remoção da classe `text-base` dos inputs da tela de login pois estavam fazendo com que o texto ficasse cortado no IOs

### Resultado das telas:
| Home | Histórico | Perfil | Cadastrar Novo Episódio |
|--------|--------|--------|--------|
| ![IMG_5550](https://github.com/user-attachments/assets/27459262-607b-4b56-8442-359598d84365) | ![IMG_5551](https://github.com/user-attachments/assets/11461125-dc15-4ee8-ac76-77828e5a37dd) | ![IMG_5552](https://github.com/user-attachments/assets/9e232152-6276-4975-90ff-1babeffd8700) | ![IMG_5553](https://github.com/user-attachments/assets/b82afe3f-6472-4ee9-b90a-6cc1a4a4484d) | 

### Registros salvos no firebase com sucesso
![image](https://github.com/user-attachments/assets/f9e7d27c-c3ed-4a40-ba6a-e93a83f6be53)
